### PR TITLE
Do not remove needed packages

### DIFF
--- a/docker-install.sh
+++ b/docker-install.sh
@@ -32,7 +32,7 @@ function run_cmd() {
     error $1
 }
 
-TEMP_PACKAGES="libgensio-dev libyaml-dev build-essential wget automake libtool openipmi make pkg-config"
+TEMP_PACKAGES="build-essential wget automake libtool openipmi make pkg-config"
 
 # command shortcuts
 APT_UPDATE="apt-get update --quiet"
@@ -44,7 +44,7 @@ rm -f /etc/apt/apt.conf.d/docker-clean
 
 # install basic packages needed
 run_cmd "apt-update" $APT_UPDATE
-run_cmd "apt-install" $APT_INSTALL $TEMP_PACKAGES tini ca-certificates
+run_cmd "apt-install" $APT_INSTALL $TEMP_PACKAGES tini ca-certificates libgensio-dev libyaml-dev
 
 ser2net_archive="/ser2net/cache/ser2net_${VERSION}.tar.gz"
 if [ ! -e "${ser2net_archive}" ]


### PR DESCRIPTION
While running this with the following `docker-compose.yaml` on a raspberry pi 4:

```
  ser2net:
    container_name: ser2net
    image: public.ecr.aws/i2s8u4z7/ser2net
    volumes:
      - ./services/ser2net/config/:/etc/ser2net/
    devices:
      - "/dev/ttyUSB0:/dev/ttyUSB0"
    restart: unless-stopped
    ports:
      - "2001:2001"
```

and the following `ser2net.yml` file:

```
%YAML 1.1
---

define: &banner \r\nser2net port \p device \d [\B] (Debian GNU/Linux)\r\n\r\n

default:
      name: local
      value: true
      class: serialdev

default:
      name: mdns
      value: false

default:
      name: mdns-sysattrs
      value: false

connection: &con0096
    accepter: tcp,2001
    enable: on
    options:
      max-connections: 5
      banner: *banner
      kickolduser: true
      telnet-brk-on-sync: true
    connector: serialdev,/dev/ttyUSB0,115200n81,local
```

ser2net would not run stating the following:

```
$ docker-compose logs -f ser2net
Attaching to ser2net
ser2net     | ser2net: error while loading shared libraries: libyaml-0.so.2: cannot open shared object file: No such file or directory
(...)
ser2net     | ser2net: error while loading shared libraries: libgensio.so.0: cannot open shared object file: No such file or directory
```

After keeping `libgensio-dev` and `libyaml-dev` ser2net runs as it should.